### PR TITLE
add dimension to target tensor to prevent valueerror 

### DIFF
--- a/discriminator.py
+++ b/discriminator.py
@@ -69,7 +69,7 @@ def do_x_training_steps(data_x, data_y, net, optimizer, loss_func, steps, graph_
     
     data_x = torch.tensor(data_x.astype(np.float32), device=device)
     data_y = torch.tensor(data_y, device=device, dtype=torch.float)
-    
+    data_y = data_y.unsqueeze(-1) # -1 adds an additional dimension to target tensor    
     net.train()
     for t in range(steps):
         predictions = net(data_x)


### PR DESCRIPTION
When using newer torch versions, the existing code throws the following error:

`ValueError: Using a target size (torch.Size([1000])) that is different to the input size (torch.Size([1000, 1])) is deprecated. Please ensure they have the same size.`

By adding an additional dimension to the target tensor this issue is resolved.

@akshat998 